### PR TITLE
Upgrade Sidekiq dependency version to 7.0

### DIFF
--- a/lib/sidekiq/cronitor.rb
+++ b/lib/sidekiq/cronitor.rb
@@ -52,7 +52,10 @@ module Sidekiq::Cronitor
         lop.history.find { |j| j[0] == worker.jid }
       end
 
-      periodic_job.present? && periodic_job.options.fetch('cronitor_key', nil)
+      return unless periodic_job
+
+      options = periodic_job.options.is_a?(String) ? JSON.parse(periodic_job.options) : periodic_job.options
+      options.fetch('cronitor_key', nil)
     end
 
     def options(worker)

--- a/lib/sidekiq/cronitor/periodic_jobs.rb
+++ b/lib/sidekiq/cronitor/periodic_jobs.rb
@@ -26,8 +26,9 @@ module Sidekiq::Cronitor
     end
 
     def self.fetch_option(lop, key)
-      lop.options.fetch(key, nil) ||
-        lop.klass.constantize.sidekiq_options.fetch(key, nil)
+      options = lop.options.is_a?(String) ? JSON.parse(lop.options) : lop.options
+
+      options&.fetch(key, nil) || lop.klass.constantize.sidekiq_options.fetch(key, nil)
     end
   end
 end

--- a/sidekiq-cronitor.gemspec
+++ b/sidekiq-cronitor.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.files         = Dir["README.md", "LICENSE", "lib/**/*.rb"]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sidekiq", "~> 6.0"
+  spec.add_dependency "sidekiq", "~> 7.0"
   spec.add_dependency "cronitor", "~> 5.0"
 
   spec.add_development_dependency "bundler", "~> 2.1"


### PR DESCRIPTION
## Changes
Periodic job options now come back as a JSON string, which needs to be parsed before accessing options.

